### PR TITLE
Add data-efficient Rainbow to leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ For sample efficiency, we can measure how many timesteps it took to train an age
 |Method| Timesteps (Best) | Timesteps (Median)| Trials | Other Info
 |---|---|---|---|---|
 |PPO | 1.274M | 2.998M | 17 | [link](https://github.com/hardmaru/slimevolleygym/blob/master/TRAINING.md)
-|Data-efficient Rainbow | 0.750M | 0.752M | 3 | [link](https://github.com/pfnet/pfrl/blob/master/examples/slimevolley/README.md)
+|Data-efficient Rainbow | 0.750M | 0.751M | 3 | [link](https://github.com/pfnet/pfrl/blob/master/examples/slimevolley/README.md)
 |[Add Method](https://github.com/hardmaru/slimevolleygym/edit/master/README.md) |  |  |  | 
 
 ### SlimeVolley-v0 (Against Other Agents)

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ For sample efficiency, we can measure how many timesteps it took to train an age
 |Method| Timesteps (Best) | Timesteps (Median)| Trials | Other Info
 |---|---|---|---|---|
 |PPO | 1.274M | 2.998M | 17 | [link](https://github.com/hardmaru/slimevolleygym/blob/master/TRAINING.md)
+|Data-efficient Rainbow | 0.750M | 0.752M | 3 | [link](https://github.com/pfnet/pfrl/blob/master/examples/slimevolley/README.md)
 |[Add Method](https://github.com/hardmaru/slimevolleygym/edit/master/README.md) |  |  |  | 
 
 ### SlimeVolley-v0 (Against Other Agents)


### PR DESCRIPTION
I applied data-efficient Rainbow to SlimeVolley-v0 and obtained results better than PPO.

For the 3 trials, timesteps to to get positive return across 1000 evalaution episodes were 750053, 751150, and 752608.